### PR TITLE
Async await

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -432,7 +432,7 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
             if (HYPER_LIBRARY.equals(getLibrary())) {
                 operation.httpMethod = StringUtils.camelize(operation.httpMethod);
             } else if (REQWEST_LIBRARY.equals(getLibrary())) {
-                operation.httpMethod = operation.httpMethod;
+                operation.httpMethod = operation.httpMethod.toLowerCase(Locale.ROOT);
             }
 
             // update return type to conform to rust standard

--- a/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
@@ -18,7 +18,7 @@ base64 = "0.7"
 futures-preview = { version = "0.3.0-alpha.19", features = ["async-await"] }
 {{/hyper}}
 {{#reqwest}}
-reqwest = { version = "0.10.0-alpha.1" }
+reqwest = { version = "0.10.0-alpha.2", features = ["json"]  }
 {{/reqwest}}
 
 [dev-dependencies]

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -1,6 +1,6 @@
 {{>partial_header}}
 use async_trait::async_trait;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::borrow::Borrow;
 #[allow(unused_imports)]
 use std::option::Option;
@@ -10,11 +10,11 @@ use reqwest;
 use super::{Error, configuration};
 
 pub struct {{{classname}}}Client {
-    configuration: Rc<configuration::Configuration>,
+    configuration: Arc<configuration::Configuration>,
 }
 
 impl {{{classname}}}Client {
-    pub fn new(configuration: Rc<configuration::Configuration>) -> {{{classname}}}Client {
+    pub fn new(configuration: Arc<configuration::Configuration>) -> {{{classname}}}Client {
         {{{classname}}}Client {
             configuration,
         }

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -225,7 +225,7 @@ impl {{{classname}}} for {{{classname}}}Client {
         Ok(())
         {{/returnType}}
         {{#returnType}}
-        Ok(client.execute(req).await?.error_for_status()?.json()?)
+        Ok(client.execute(req).await?.error_for_status()?.json().await?)
         {{/returnType}}
     }
 

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/client.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/client.mustache
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::configuration::Configuration;
 
@@ -18,7 +18,7 @@ pub struct APIClient {
 
 impl APIClient {
     pub fn new(configuration: Configuration) -> APIClient {
-        let rc = Rc::new(configuration);
+        let rc = Arc::new(configuration);
 
         APIClient {
 {{#apiInfo}}


### PR DESCRIPTION
Some help with https://github.com/OpenAPITools/openapi-generator/pull/4210

This may take a while. The next issue has something to do with [async_trait](https://github.com/dtolnay/async-trait):
```
42 | #[async_trait]
   | ^^^^^^^^^^^^^^ `std::rc::Rc<apis::configuration::Configuration>` cannot be shared between threads safely
   |
   = help: within `apis::tenant_api::TenantApiClient`, the trait `std::marker::Sync` is not implemented for `std::rc::Rc<apis::configuration::Configuration>`
```

I'll probably investigate more tomorrow. This can be merged as is if you want.